### PR TITLE
feat: Se agrega los campos solicitados para las tablas plan_adquisici…

### DIFF
--- a/controllers/Registro_plan_adquisiciones.go
+++ b/controllers/Registro_plan_adquisiciones.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
-	"github.com/udistrital/plan_adquisiciones_crud/models"
 	"strconv"
 	"strings"
+
+	"github.com/udistrital/plan_adquisiciones_crud/models"
 
 	"github.com/udistrital/utils_oas/time_bogota"
 
@@ -39,6 +40,8 @@ func (c *RegistroPlanAdquisicionesController) Post() {
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		v.FechaCreacion = time_bogota.TiempoBogotaFormato()
 		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
+		// v.FechaEstimadaInicio = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaInicio)
+		// v.FechaEstimadaFin = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaFin)
 		if _, err := models.AddRegistroPlanAdquisiciones(&v); err == nil {
 			c.Ctx.Output.SetStatus(201)
 			c.Data["json"] = v
@@ -163,6 +166,8 @@ func (c *RegistroPlanAdquisicionesController) Put() {
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		v.FechaCreacion = time_bogota.TiempoCorreccionFormato(v.FechaCreacion)
 		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
+		v.FechaEstimadaInicio = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaInicio)
+		v.FechaEstimadaFin = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaFin)
 		if err := models.UpdateRegistroPlanAdquisicionesById(&v); err == nil {
 			c.Data["json"] = v
 		} else {

--- a/controllers/Registro_plan_adquisiciones.go
+++ b/controllers/Registro_plan_adquisiciones.go
@@ -40,8 +40,8 @@ func (c *RegistroPlanAdquisicionesController) Post() {
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		v.FechaCreacion = time_bogota.TiempoBogotaFormato()
 		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
-		// v.FechaEstimadaInicio = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaInicio)
-		// v.FechaEstimadaFin = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaFin)
+		v.FechaEstimadaInicio = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaInicio)
+		v.FechaEstimadaFin = time_bogota.TiempoCorreccionFormato(v.FechaEstimadaFin)
 		if _, err := models.AddRegistroPlanAdquisiciones(&v); err == nil {
 			c.Ctx.Output.SetStatus(201)
 			c.Data["json"] = v

--- a/database/migrations/20201123_092348_modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.go
+++ b/database/migrations/20201123_092348_modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/astaxie/beego/migration"
+)
+
+// DO NOT MODIFY
+type ModificacionTablasPlanAdquicisionesYRegistroPlanAdquisiciones_20201123_092348 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &ModificacionTablasPlanAdquicisionesYRegistroPlanAdquisiciones_20201123_092348{}
+	m.Created = "20201123_092348"
+
+	migration.Register("ModificacionTablasPlanAdquicisionesYRegistroPlanAdquisiciones_20201123_092348", m)
+}
+
+// Run the migrations
+func (m *ModificacionTablasPlanAdquicisionesYRegistroPlanAdquisiciones_20201123_092348) Up() {
+
+	file, err := ioutil.ReadFile("../scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.up.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}
+
+// Reverse the migrations
+func (m *ModificacionTablasPlanAdquicisionesYRegistroPlanAdquisiciones_20201123_092348) Down() {
+	file, err := ioutil.ReadFile("../scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.down.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+
+}

--- a/database/scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.down.sql
+++ b/database/scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE plan_adquisiciones."Plan_adquisiciones"
+	DROP COLUMN IF EXISTS publicado;
+	
+ALTER TABLE plan_adquisiciones."Registro_plan_adquisiciones"
+	DROP COLUMN IF EXISTS rubro_id,
+	DROP COLUMN IF EXISTS fecha_estimada_inicio,
+	DROP COLUMN IF EXISTS fecha_estimada_fin;

--- a/database/scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.up.sql
+++ b/database/scripts/modificacion_tablas_plan_adquicisiones_y_registro_plan_adquisiciones.up.sql
@@ -1,0 +1,21 @@
+-- ALTER TABLE plan_adquisiciones."Plan_adquisiciones" DROP COLUMN IF EXISTS "publicado";
+ALTER TABLE plan_adquisiciones."Plan_adquisiciones"
+	ADD COLUMN publicado bool NOT NULL;
+
+-- ddl-end --
+COMMENT ON COLUMN plan_adquisiciones."Plan_adquisiciones".publicado IS E'Verificar si estado de publicacion del plan de adquisicion';
+
+
+
+-- ALTER TABLE plan_adquisiciones."Registro_plan_adquisiciones" DROP COLUMN IF EXISTS "publicado","fecha_estimada_inicio","fecha_estimada_fin";
+ALTER TABLE plan_adquisiciones."Registro_plan_adquisiciones"
+	ADD COLUMN rubro_id text NOT NULL,
+	ADD COLUMN fecha_estimada_inicio timestamp NOT NULL,
+	ADD COLUMN fecha_estimada_fin timestamp NOT NULL;
+
+-- ddl-end --
+COMMENT ON COLUMN plan_adquisiciones."Registro_plan_adquisiciones".rubro_id IS E'Conocer a que rubro pertenece el registro y poder usarse para ordenar los registros';
+-- ddl-end --
+COMMENT ON COLUMN plan_adquisiciones."Registro_plan_adquisiciones".fecha_estimada_inicio IS E'Fecha estimada de inicio del proceso';
+-- ddl-end --
+COMMENT ON COLUMN plan_adquisiciones."Registro_plan_adquisiciones".fecha_estimada_fin IS E'Fecha estimada de finalizacion del proceso';

--- a/models/Plan_adquisiciones.go
+++ b/models/Plan_adquisiciones.go
@@ -16,6 +16,7 @@ type PlanAdquisiciones struct {
 	FechaCreacion     string `orm:"column(fecha_creacion);type(timestamp without time zone)"`
 	FechaModificacion string `orm:"column(fecha_modificacion);type(timestamp without time zone)"`
 	Activo            bool   `orm:"column(activo)"`
+	Publicado         bool   `orm:"column(publicado)"`
 }
 
 func (t *PlanAdquisiciones) TableName() string {

--- a/models/Registro_plan_adquisiciones.go
+++ b/models/Registro_plan_adquisiciones.go
@@ -19,6 +19,9 @@ type RegistroPlanAdquisiciones struct {
 	Activo              bool               `orm:"column(activo)"`
 	MetaId              string             `orm:"column(meta_id);null"`
 	ProductoId          string             `orm:"column(producto_id);null"`
+	RubroId             string             `orm:"column(rubro_id)"`
+	FechaEstimadaInicio string             `orm:"column(fecha_estimada_inicio);type(timestamp without time zone)"`
+	FechaEstimadaFin    string             `orm:"column(fecha_estimada_fin);type(timestamp without time zone)"`
 	PlanAdquisicionesId *PlanAdquisiciones `orm:"column(Plan_adquisiciones_id);rel(fk)"`
 }
 

--- a/models/plan_adquisiciones_mongo.go
+++ b/models/plan_adquisiciones_mongo.go
@@ -17,6 +17,7 @@ type PlanAdquisicionesMongo struct {
 	FechaCreacion             string                           `json:"fecha_creacion"`
 	FechaModificacion         string                           `json:"fecha_modificacion"`
 	Activo                    bool                             `json:"activo"`
+	Publicado                 bool                             `json:"publicado"`
 	FichaEbImga               []FichaEBIMGA                    `json:"ficha_eb_imga"`
 	RegistroPlanAdquisiciones []RegistroPlanAdquisicionesMongo `json:"registro_plan_adquisiciones"`
 }
@@ -45,6 +46,9 @@ type RegistroPlanAdquisicionesMongo struct {
 	ResponsableID                            int                                             `json:"responsable_id"`
 	Activo                                   bool                                            `json:"activo"`
 	ProductoID                               string                                          `json:"producto_id"`
+	RubroID                                  string                                          `json:"rubro_id"`
+	FechaEstimadaInicio                      string                                          `json:"fecha_estimada_inicio"`
+	FechaEstimadaFin                         string                                          `json:"fecha_estimada_fin"`
 	RegistroPlanAdquisicionesCodigoArka      []RegistroPlanAdquisicionesCodigoArkaMongo      `json:"registro_plan_adquisiciones-codigo_arka"`
 	RegistroFuncionamientoModalidadSeleccion []RegistroFuncionamientoModalidadSeleccionMongo `json:"registro_funcionamiento-modalidad_seleccion"`
 	RegistroPlanAdquisicionesActividad       []RegistroPlanAdquisicionesActividadMongo       `json:"registro_plan_adquisiciones-actividad"`


### PR DESCRIPTION
…on y registro_plan_adquisicion #17

- Se agrega el campo publicado de tipo bool a la tabla plan_adquiscion.

- Se agregan los campos rubro_id tipo text, fecha_estimada_inicio, tipo timestamp, fecha_estimada_fin, tipo timestamp  a la tabla registro_plan_adquiscion.

- Se  añade archivos script y migraciones.

- Se modifica  el modelo de go del plan de adquisiciones para añadirle la propiedad

- Se modifica el modelo de go del registro plan de adquisiciones para añadirle las propiedades

- Se modifica  el modelo de mongo de plan de adquisiciones añadiendo el campo.

- Se modifica  el modelo de mongo de plan de registro adquisiciones añadiendo los campos.